### PR TITLE
Correct part number in library name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Adafruit AS276X
+name=Adafruit AS726X
 version=1.0.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>


### PR DESCRIPTION
The part family is AS726X but previously the library name called it "AS276X".

If possible, I would suggest getting this merged and in a release ASAP. The reason being that once the library is added to the Arduino Library Manager index (https://github.com/arduino/Arduino/issues/9224), the library name used in Library Manager is "locked in" and you must make a request for the name to be manually updated.