### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_AS726x.cpp
+++ b/Adafruit_AS726x.cpp
@@ -26,6 +26,11 @@
 
 #include "Adafruit_AS726x.h"
 
+Adafruit_AS726x::~Adafruit_AS726x(void) {
+  if (i2c_dev)
+    delete i2c_dev;
+}
+
 /**************************************************************************/
 /*!
     @brief  Set up hardware and begin communication with the sensor
@@ -34,6 +39,8 @@
 */
 /**************************************************************************/
 bool Adafruit_AS726x::begin(TwoWire *theWire) {
+  if (i2c_dev)
+    delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(_i2caddr, theWire);
   if (!i2c_dev->begin()) {
     return false;

--- a/Adafruit_AS726x.h
+++ b/Adafruit_AS726x.h
@@ -180,7 +180,7 @@ public:
      0x49.
   */
   Adafruit_AS726x(int8_t addr = AS726x_ADDRESS) { _i2caddr = addr; };
-  ~Adafruit_AS726x(void){};
+  ~Adafruit_AS726x(void);
 
   bool begin(TwoWire *theWire = &Wire);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit AS726X
-version=1.2.0
+version=1.2.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Adafruit Channel Visible Light / Color Sensor Breakout


### PR DESCRIPTION
Tested on Qt PY.

```cpp
#include "Adafruit_AS726x.h"

Adafruit_AS726x ams;

uint16_t sensorValues[AS726x_NUM_CHANNELS];

void setup() {
  Serial.begin(9600);
  while(!Serial);
 
  Serial.println("AS7262 test.");
}

void loop() {
  if(!ams.begin()){
    Serial.println("could not connect to sensor! Please check your wiring.");
    while(1);
  }
  
  uint8_t temp = ams.readTemperature();
  
  ams.startMeasurement(); //begin a measurement
  
  bool rdy = false;
  while(!rdy){
    delay(5);
    rdy = ams.dataReady();
  }

  ams.readRawValues(sensorValues);

  Serial.print("Temp: "); Serial.print(temp);
  Serial.print(" Violet: "); Serial.print(sensorValues[AS726x_VIOLET]);
  Serial.print(" Blue: "); Serial.print(sensorValues[AS726x_BLUE]);
  Serial.print(" Green: "); Serial.print(sensorValues[AS726x_GREEN]);
  Serial.print(" Yellow: "); Serial.print(sensorValues[AS726x_YELLOW]);
  Serial.print(" Orange: "); Serial.print(sensorValues[AS726x_ORANGE]);
  Serial.print(" Red: "); Serial.print(sensorValues[AS726x_RED]);
  Serial.println();
  Serial.println();

  delay(1000);
}
```

![Screenshot from 2021-09-02 10-42-07](https://user-images.githubusercontent.com/8755041/131891773-7f4a59cd-1363-4657-840c-3b1e8476bd1a.png)
